### PR TITLE
Fixed typo in title of 'Docs for identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       "description": "Type of identifier"
     }, {
       "command": "idris.docs-for",
-      "title": "Idris: dosc for",
+      "title": "Idris: docs for",
       "description": "Docs for identifier"
     }, {
       "command": "idris.print-definition",


### PR DESCRIPTION
Hi there - great extension, I get much better performance than I do in Atom!

Anyway, I spotted and fixed a minor typo.