### PR TITLE
Adding Live Share support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.9.8",
   "publisher": "zjhmale",
   "engines": {
-    "vscode": "^1.8.0"
+    "vscode": "^1.30.0"
   },
   "icon": "images/idris.png",
   "keywords": [
@@ -422,6 +422,6 @@
   },
   "devDependencies": {
     "eslint": "^3.19.0",
-    "vscode": "^1.0.5"
+    "vscode": "^1.1.34"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.9.8",
   "publisher": "zjhmale",
   "engines": {
-    "vscode": "^1.30.0"
+    "vscode": "^1.31.0"
   },
   "icon": "images/idris.png",
   "keywords": [

--- a/src/extension.js
+++ b/src/extension.js
@@ -28,13 +28,21 @@ function activate(context) {
     }
   })
 
-  context.subscriptions.push(controller.tcDiagnosticCollection)
-  context.subscriptions.push(controller.buildDiagnosticCollection)
-  context.subscriptions.push(controller.nonTotalDiagnosticCollection)
   controller.getCommands().forEach(([key, value]) => {
     let disposable = vscode.commands.registerCommand(key, value)
     context.subscriptions.push(disposable)
   })
+
+  // If the end-user is joined into a Live Share session, then there's no need
+  // to register any of the language services or document event handlers.
+  if (vscode.workspace.workspaceFolders.find((folder) => folder.uri.scheme === "vsls")) {
+    return;
+  }
+
+  context.subscriptions.push(controller.tcDiagnosticCollection)
+  context.subscriptions.push(controller.buildDiagnosticCollection)
+  context.subscriptions.push(controller.nonTotalDiagnosticCollection)
+
   context.subscriptions.push(vscode.languages.registerCompletionItemProvider(controller.IDRIS_MODE, new idrisCompletion.IdrisCompletionProvider(), ...triggers))
   context.subscriptions.push(vscode.languages.registerHoverProvider(controller.IDRIS_MODE, new idrisHover.IdrisHoverProvider()))
   context.subscriptions.push(vscode.languages.registerDefinitionProvider(controller.IDRIS_MODE, new idrisDefinition.IdrisDefinitionProvider()))


### PR DESCRIPTION
This PR simply adds [Live Share support](https://aka.ms/vsls). When a "guest" joins someones Live Share session, all language services are computed on the host's side, and therefore, the "guest" doesn't need to try to compute them locally.